### PR TITLE
fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@
         <h2 id="config"><a href="#"config">Configuration</a></h2>
 
         <p>The <code>config</code> object seen above in <code>~/.hyperterm.js</code>
-        admis the following</p>
+        admits the following</p>
 
         <table class="config">
           <thead>


### PR DESCRIPTION
Fixed spelling of the word "admits" from "admis."