### PR TITLE
Fixes horizontal scroll caused by 100vw on #top

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,6 +96,7 @@
         width: 100vw;
         position: relative;
         text-align: center;
+        max-width: 100%;
       }
 
       #arrow {


### PR DESCRIPTION
[The spec on viewport-percentage lengths](https://www.w3.org/TR/css3-values/#viewport-relative-lengths) says:

> Note that the initial containing block’s size is affected by the presence of scrollbars on the viewport

This makes vw/vh convenient to use again. 😃 