### PR TITLE
Update config docs for the new color object syntax

### DIFF
--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@
             <tr>
               <td>"colors"</td>
               <td>{ black: "#000000", red: "#ff0000", ... }</td>
-              <td>A list of overrides for the color palette. The names of the keys represent the "ANSI 16", which can all be seen <a href="https://github.com/zeit/hyperterm/blob/master/config-default.js#L32">in the default config</a>.</td>
+              <td>A list of overrides for the color palette. The names of the keys represent the "ANSI 16", which can all be seen <a href="https://github.com/zeit/hyperterm/pull/193/commits/970eac21cc6ac9f93083c3b9d3f8ac7edbb6fe2a#diff-1dfee92b62e747055fc44e019d136750R30">in the default config</a>.</td>
             </tr>
           </tbody>
         </table>

--- a/index.html
+++ b/index.html
@@ -533,7 +533,7 @@
             </tr>
             <tr>
               <td>"colors"</td>
-              <td>["#000000", "#ff0000", ...]</td>
+              <td>{ black: "#000000", red: "#ff0000", ... }</td>
               <td>A list of overrides for the color palette</td>
             </tr>
           </tbody>
@@ -1097,7 +1097,7 @@
 
         <p>I grabbed the class names by inspecting the term with
         Devtools, which you can trigger from <code>View -&gt; Toggle Developer Tools</code>.
-        When you do so, notice that some classes are automatically generated and 
+        When you do so, notice that some classes are automatically generated and
         followed by a random nonce (e.g.: <code>term_13hv8io</code>). Ignore those: they change with every new window!</p>
 
         <p>Notice the emphasis on playing nice with other extensions.

--- a/index.html
+++ b/index.html
@@ -534,7 +534,7 @@
             <tr>
               <td>"colors"</td>
               <td>{ black: "#000000", red: "#ff0000", ... }</td>
-              <td>A list of overrides for the color palette</td>
+              <td>A list of overrides for the color palette. The names of the keys represent the "ANSI 16", which can all be seen <a href="https://github.com/zeit/hyperterm/blob/master/config-default.js#L32">in the default config</a>.</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
This documents the change from an array to an object for the colors. Directly related to zeit/hyperterm#193