### PR TITLE
add documentation for windowSize option

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,6 +547,11 @@
               <td>npm get registry</td>
               <td>Override the npm registry URL to use when installing plugins</td>
             </tr>
+            <tr>
+              <td>"windowSize"</td>
+              <td>null</td>
+              <td>The default width/height in pixels of a new window e.g. [540, 380]</td>
+            </tr>
           </tbody>
         </table>
         <span class="table-note"></span>


### PR DESCRIPTION
"default" left as null since this config is optional, but provided an example value in the description.